### PR TITLE
Remove unnecessary closePath calls.

### DIFF
--- a/services/rendering.js
+++ b/services/rendering.js
@@ -23,14 +23,12 @@ gameApp.factory('renderingService', ['tileMap', function(tileMap) {
             this.spriteCtx.arc(circle.location.x, circle.location.y, circle.radius, 0, Math.PI*2, false);
             this.spriteCtx.fillStyle = circle.color;
             this.spriteCtx.fill();
-            this.spriteCtx.closePath();
         },
         drawFloor: function() {
             this.spriteCtx.beginPath();
             this.spriteCtx.rect(0, this.spriteLayer.height - 10, this.spriteLayer.width, 10);
             this.spriteCtx.fillStyle = 'red';
             this.spriteCtx.fill();
-            this.spriteCtx.closePath();
         },
         clearCanvas: function() {
             this.spriteCtx.clearRect(0, 0, this.spriteLayer.width, this.spriteLayer.height);


### PR DESCRIPTION
Realized today that we've been using the `closePath` method incorrectly in the rendering service. Removed it, as it's unnecessary.
